### PR TITLE
Updated commands.py to use latin-1 decoder

### DIFF
--- a/qds_sdk/commands.py
+++ b/qds_sdk/commands.py
@@ -795,7 +795,7 @@ def _read_iteratively(key_instance, fp, delim):
         try:
             # Default buffer size is 8192 bytes
             data = next(key_instance)
-            fp.write(str(data).replace(chr(1), delim))
+            fp.write(data.decode('latin-1').replace(chr(1), delim))
         except StopIteration:
             # Stream closes itself when the exception is raised
             return


### PR DESCRIPTION
Using `str()` of a binary creates a binarized version, which cannot be read as a CSV/TSV. Decode creates the correct string representation

example -

    In [45]: bin1 = b'hello\tworld'
    
    In [46]: print(str(bin1))
    b'hello\tworld'
    
    In [47]: str(bin1)
    Out[47]: "b'hello\\tworld'"
    
    In [48]: print(bin1.decode('latin-1'))
    hello	world
    
    In [49]: bin1.decode('latin-1')
    Out[49]: 'hello\tworld'

Without this fix, the resulting TSV looked like this -

    In [50]: !head ias_tmp.bin.tsv 
    b'created_dt\tcampaign_uid\tview_status\tnum_impressions\n'b'2014-10-23\x010CiwqDOm6X\x01outOfView\x016172\n2014-10-24\x010CdZDRR9da\x01inView\x01520564\n'b'2014-10-21\x010CdZDR243R9da\x01N/A\x011\n'b'2014-10-24\x010CdZDRR9da\x01outOfView\x01136400\n'b'2014-10-21\x010CFPqJIuzd\x01outOfView\x01263424\n'b'2014-10-22\x010C8tYQCO8T\x01N/A\x0164\n'b'2014-10-22\x0130\x01N/A\x012\n'b'2014-10-20\x010CdZDRR9da\x01inView\x01667086\n'b'2014-10-20\x010CdZDRR9da\x01outOfView\x01302841\n'b'2014-10-23\x010CHLQ8buI4\x01inView\x012065\n'b'2014-10-23\x010CHLQ8buI4\x01outOfView\x014739\n'b'2014-10-21\x017\x01N/A\x011\n'b'2014-10-23\x010CiwqDOm6X\x01N/A\x0112289\n'b'2014-10-24\x010CdZDRR9da\

With the fix - 

    In [51]: !head ias_tmp.tsv
    created_dt  campaign_uid    view_status num_impressions
    2014-10-23  0CiwqDOm6X  outOfView   6172
    2014-10-24  0CdZDRR9da  inView  520564
    2014-10-21  0CdZDR243R9da   N/A 1
    2014-10-24  0CdZDRR9da  outOfView   136400
    2014-10-21  0CFPqJIuzd  outOfView   263424
    2014-10-22  0C8tYQCO8T  N/A 64
    2014-10-22  30  N/A 2
    2014-10-20  0CdZDRR9da  inView  667086
    2014-10-20  0CdZDRR9da  outOfView   302841